### PR TITLE
Use separate seed values for indexes.

### DIFF
--- a/lib/haikunator.rb
+++ b/lib/haikunator.rb
@@ -4,17 +4,15 @@ require "securerandom"
 module Haikunator
   class << self
     def haikunate(token_range = 9999, delimiter = "-")
-      seed = random_seed
-
-      build(seed, token_range, delimiter)
+      build(token_range, delimiter)
     end
 
     private
 
-    def build(seed, token_range, delimiter)
+    def build(token_range, delimiter)
       sections = [
-        adjectives[seed % adjectives.length],
-        nouns[seed % nouns.length],
+        adjectives[random_seed % adjectives.length],
+        nouns[random_seed % nouns.length],
         token(token_range)
       ]
 


### PR DESCRIPTION
This commit fixes a bug where the same seed value was being used for
both the adjectives and nouns indexes.  This had greatly limited the
uniqueness of generated names.
